### PR TITLE
chore: update golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with: { go-version-file: go.mod }
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with: { version: v2.1.6 }
 
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
-        with: { version: v1.60 }
+        with: { version: v2.1.6 }
 
   fmt:
     name: Fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: '1.23' }
+        with: { go-version-file: go.mod }
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: '1.23' }
+        with: { go-version-file: go.mod }
 
       - name: Fmt
         run: |
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-        with: { go-version: '1.23' }
+        with: { go-version-file: go.mod }
 
       - name: Test
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 5m
   tests: false
 linters:
   disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,41 @@
+version: "2"
 run:
-  timeout: 5m
   tests: false
 linters:
-  # enable-all: true
   disable:
     - contextcheck
     - depguard
     - err113
     - errchkjson
-    - execinquery
     - exhaustruct
     - goconst
-    - gomnd
     - ireturn
     - lll
     - mnd
     - varnamelen
     - wrapcheck
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/cugu/templum)
-issues:
-  exclude-dirs:
-    - theme
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - theme
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/cugu/templum)
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Summary
- migrate golangci-lint config to v2
- run golangci-lint migration tool
- use golangci-lint v2 in CI workflow

## Testing
- `golangci-lint run`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fe1b54c448332b0b5043c746aa6d3